### PR TITLE
Add support for scheduled Faktory jobs

### DIFF
--- a/src/FaktoryJob.php
+++ b/src/FaktoryJob.php
@@ -6,18 +6,60 @@ class FaktoryJob implements \JsonSerializable {
     private $id;
     private $type;
     private $args;
+    private $at;
 
     public function __construct($type, $args) {
         $this->id = uniqid();
         $this->type = $type;
         $this->args = $args;
+        $this->at = date(DATE_RFC3339);
     }
 
     public function jsonSerialize() {
         return [
             'jid' => $this->id,
             'jobtype' => $this->type,
-            'args' => $this->args
+            'args' => $this->args,
+            'at' => $this->at,
         ];
+    }
+
+    public function inSeconds($seconds) {
+        if (!is_numeric($seconds)) {
+            throw new \Exception('expected a number in seconds');
+        }
+        $date = date(DATE_RFC3339, time() + $seconds);
+        $this->at($date);
+    }
+
+    public function inMinutes($minutes) {
+        if (!is_numeric($minutes)) {
+            throw new \Exception('expected a number in minutes');
+        }
+        $seconds = $minutes * 60;
+        $date = date(DATE_RFC3339, time() + $seconds);
+        $this->at($date);
+    }
+
+    public function inHours($hours) {
+        if (!is_numeric($hours)) {
+            throw new \Exception('expected a number in hours');
+        }
+        $seconds = $hours * 3600;
+        $date = date(DATE_RFC3339, time() + $seconds);
+        $this->at($date);
+    }
+
+    public function at($date) {
+        if (!$this->validateDate($date)) {
+            throw new \Exception('expected a date in RFC3339 format');
+        }
+
+        $this->at = $date;
+    }
+
+    private function validateDate($date, $format = DATE_RFC3339) {
+        $d = \DateTime::createFromFormat($format, $date);
+        return $d && $d->format($format) === $date;
     }
 }


### PR DESCRIPTION
## Overview
Adds the ability to schedule jobs. In the example below I included a standard (non-scheduled) job to show no regression in existing functionality. 

Example usage: 
```php
$client = new FaktoryClient('faktory', '7419');

$job1 = new FaktoryJob('CoolJob1', [
    1,
    2
]);

$job2 = new FaktoryJob('CoolJob2', [
    3,
    4
]);

$job3 = new FaktoryJob('CoolJob3', [
    5,
    6
]);

$job4 = new FaktoryJob('CoolJob4', [
    7,
    8
]);

$job5 = new FaktoryJob('CoolJob5', [
    9,
    10
]);

$job1->inSeconds(300);
$job2->inMinutes(15);
$job3->inHours(24);

$date = date(DATE_RFC3339, strtotime('+5 days'));
$job4->at($date);    

$client->push($job1);
$client->push($job2);
$client->push($job3);
$client->push($job4);
$client->push($job5);
```
Faktory Dashboard from the above code: 
![image](https://user-images.githubusercontent.com/24882745/87890677-741e2000-ca05-11ea-92e6-42e25baa9a8e.png)

